### PR TITLE
Updated Deprecations on player items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 out/*
 #Intellij iml file
 Ultimate FireworkShow.iml
+UltimateFireworkShow.iml

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 #Intellij project config
 .idea/
-
+out/*
 #Intellij iml file
 Ultimate FireworkShow.iml

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,8 +1,8 @@
+version: 1.0.2
 name: FireworkShow
-author: iGufGuf
-version: 1.0.1
-description: 'The best FireworkShow plugin for scheduled and customized firework effects!'
+author: [iGufGuf, Jackietkfrost, Zuwel]
 main: com.igufguf.fireworkshow.Main
+api-version: 1.14
 commands:
   fireworkshow:
     description: Basic fireworkshow command

--- a/plugin.yml
+++ b/plugin.yml
@@ -5,5 +5,5 @@ main: com.igufguf.fireworkshow.Main
 api-version: 1.14
 commands:
   fireworkshow:
-    description: Basic fireworkshow command
-    aliases: [fws]
+    description: Basic Fireworkshow command
+    aliases: fws

--- a/src/com/igufguf/fireworkshow/Main.java
+++ b/src/com/igufguf/fireworkshow/Main.java
@@ -114,7 +114,7 @@ public class Main extends JavaPlugin {
             Show show = shows.get(args[1].toLowerCase());
 
             if ( show.isRunning() ) {
-                sender.sendMessage(ChatColor.GREEN + "ireworkshow " + ChatColor.DARK_GREEN + args[1].toLowerCase() + ChatColor.GREEN + " is already running!");
+                sender.sendMessage(ChatColor.GREEN + "fireworkshow " + ChatColor.DARK_GREEN + args[1].toLowerCase() + ChatColor.GREEN + " is already running!");
                 return true;
             }
 

--- a/src/com/igufguf/fireworkshow/Main.java
+++ b/src/com/igufguf/fireworkshow/Main.java
@@ -314,11 +314,11 @@ public class Main extends JavaPlugin {
             }
 
             Player p = (Player) sender;
-            if ( p.getItemInHand() == null || p.getItemInHand().getType() != Material.FIREWORK ) {
+            if ( p.getInventory().getItemInMainHand() == null ||p.getInventory().getItemInMainHand().getType() != Material.FIREWORK_ROCKET){
                 sender.sendMessage(ChatColor.RED + "Please hold a firework or firework charge in your hand!");
                 return true;
             }
-            FireworkMeta meta = (FireworkMeta) p.getItemInHand().getItemMeta();
+            FireworkMeta meta = (FireworkMeta) p.getInventory().getItemInMainHand().getItemMeta();
 
             NormalFireworks nf = new NormalFireworks(meta, p.getLocation());
             shows.get(name).get(frame-1).add(nf);


### PR DESCRIPTION
getiteminhand is deprecated, and is now  getinventory().getiteminmainhand() (Since now we can hold items in off-hand) 
Credit to Zuwel, and Choco(https://www.spigotmc.org/threads/getiteminhand-alternative.159987/)

Also fixed Material referenced, as FIREWORK is now deprecated, and it's called FIREWORK_ROCKET