### PR TITLE
Fix to newfw command error

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,4 +1,4 @@
-version: 2.0.1
+version: 2.0.2
 name: FireworkShow
 authors: [iGufGuf, Jackietkfrost, Zuwel]
 main: com.igufguf.fireworkshow.FireworkShow

--- a/src/com/igufguf/fireworkshow/commands/CommandHandler.java
+++ b/src/com/igufguf/fireworkshow/commands/CommandHandler.java
@@ -302,6 +302,11 @@ public class CommandHandler implements CommandExecutor {
                 return true;
             }
 
+            if (FireworkShow.getShows().get(name).frames.isEmpty()) {
+                sender.sendMessage(ChatColor.RED + "There are no frames in this show!");
+                return true;
+            }
+
             int frame;
             if (args.length == 3)
             {


### PR DESCRIPTION
Error happened when a new firework was attempted to be added to a show with no frames. Added necessary error checks.